### PR TITLE
口語表現特有のフィラーを取り除くために、形態素解析を行う

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Docker.DotNet"]
+	path = Docker.DotNet
+	url = https://github.com/microsoft/Docker.DotNet.git

--- a/Program.cs
+++ b/Program.cs
@@ -54,7 +54,7 @@ namespace SpeechRecogSample
             var client = new DockerClientConfiguration().CreateClient();
             var createContainerResponse = await client.Containers.CreateContainerAsync(new CreateContainerParameters
             {
-                Cmd = new[] { "mecab", Path.Combine(TempDirInDocker, InputFileName), "-o", Path.Combine(TempDirInDocker, OutputFileName) },
+                Cmd = new[] { "mecab", $"{TempDirInDocker}/{InputFileName}", "-o", $"{TempDirInDocker}/{OutputFileName}" },
                 Image = "intimatemerger/mecab-ipadic-neologd",
                 HostConfig = new HostConfig
                 {

--- a/SpeechRecogSample.csproj
+++ b/SpeechRecogSample.csproj
@@ -23,7 +23,8 @@
   <Target Name="CompileDependentLibrary" BeforeTargets="Restore">
     <!-- Todo: nupkgファイルが既に生成されていたらスキップ -->
     <!-- https://docs.microsoft.com/en-us/visualstudio/msbuild/property-functions -->
-    <Exec Command="dotnet restore Docker.DotNet; dotnet publish -f netstandard2.0 $([MSBuild]::NormalizePath('Docker.DotNet', 'src', 'Docker.DotNet'))" />
+    <Exec Command="dotnet restore Docker.DotNet" />
+    <Exec Command="dotnet publish -f netstandard2.0 $([MSBuild]::NormalizePath('Docker.DotNet', 'src', 'Docker.DotNet'))" />
   </Target>
 
 </Project>

--- a/SpeechRecogSample.csproj
+++ b/SpeechRecogSample.csproj
@@ -3,13 +3,27 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <!-- Localのnupkgを優先する -->
+    <RestoreSources>Docker.DotNet\src\Docker.DotNet\bin;$(RestoreSources);</RestoreSources>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.6.0" />
     <PackageReference Include="CsvHelper" Version="12.2.2" />
+    <PackageReference Include="Docker.DotNet" Version="3.125.3" />
     <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.8.0" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Docker.DotNet\**" />
+  </ItemGroup>
+
+  <!-- Restore前にBuildを終わらせないと、Restoreが出来ない -->
+  <Target Name="CompileDependentLibrary" BeforeTargets="Restore">
+    <!-- Todo: nupkgファイルが既に生成されていたらスキップ -->
+    <!-- https://docs.microsoft.com/en-us/visualstudio/msbuild/property-functions -->
+    <Exec Command="dotnet restore Docker.DotNet; dotnet publish -f netstandard2.0 $([MSBuild]::NormalizePath('Docker.DotNet', 'src', 'Docker.DotNet'))" />
+  </Target>
 
 </Project>

--- a/SpeechRecogSample.csproj
+++ b/SpeechRecogSample.csproj
@@ -4,19 +4,22 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <!-- Localのnupkgを優先する -->
-    <RestoreSources>Docker.DotNet\src\Docker.DotNet\bin;$(RestoreSources);</RestoreSources>
+    <!-- <RestoreSources>Docker.DotNet\src\Docker.DotNet\bin;$(RestoreSources);</RestoreSources> -->
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.6.0" />
     <PackageReference Include="CsvHelper" Version="12.2.2" />
-    <PackageReference Include="Docker.DotNet" Version="3.125.3" />
+    <!-- <PackageReference Include="Docker.DotNet" Version="3.125.3" /> -->
     <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.8.0" />
     <PackageReference Include="System.Reactive" Version="4.3.2" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Remove="Docker.DotNet\**" />
+    <Reference Include="Docker.DotNet">
+      <HintPath>Docker.DotNet\src\Docker.DotNet\bin\*\netstandard2.0\publish\Docker.DotNet.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
   <!-- Restore前にBuildを終わらせないと、Restoreが出来ない -->


### PR DESCRIPTION
Windows 10 HomeでもInsidersならDocker使えるようになったし、形態素解析を行うことが出来るアプリケーションのDocker ImageをC# アプリケーションから呼ぶ形で使う。

本来であればttyを掴んでStreamをハンドリングするほうが良さそうだけど、Docker.DotNetのバグがあるらしく、一つのStreamをWriteとReadに使うのがダメだったので、ファイル入出力で行う。